### PR TITLE
Change compilation source and target to Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,8 +237,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Java 6 is no longer supported in current compilers.